### PR TITLE
docs: add InfiniteDSH

### DIFF
--- a/categories/fun.md
+++ b/categories/fun.md
@@ -4,7 +4,7 @@
 > Games, pets, entertainment, and playful plugins.
 
 
-**5 plugins**
+**6 plugins**
 
 
 ---
@@ -13,9 +13,10 @@
 - [gameswu/dsh-pref-kit](https://github.com/gameswu/dsh-pref-kit) ⭐4 — 缓解部分dsh性能问题的插件
 - [pk7j7sqryy-ops/dsh-token-pet](https://github.com/pk7j7sqryy-ops/dsh-token-pet) ⭐1 — DSH 动态 Cordis 插件：卡通用量小部件 + 天气/预报/预警（Token Pet 布布玩偶）
 - [gameswu/dsh-cross-collaboration](https://github.com/gameswu/dsh-cross-collaboration) ⭐1 — dsh跨设备agent协作插件
+- [vdnight89/InfiniteDSH](https://github.com/vdnight89/InfiniteDSH) ⭐1 — 诸天万界DSH：一个会话就是一本书。封面开书十九界，文学预设只写正文，规则书按关键词注入，/export-story 誊成 Markdown 小说。
 - [sorry123maker/dsh-salary-cat](https://github.com/sorry123maker/dsh-salary-cat) — dsh的月薪猫宠物
 
 ---
 
 
-*Generated on 2026-08-18 · 5 plugins in this category*
+*Generated on 2026-08-18 · 6 plugins in this category*


### PR DESCRIPTION
诸天万界DSH：一个会话就是一本书。封面开书十九界，文学预设只写正文，规则书按关键词注入，/export-story 誊成 Markdown 小说。

- 19 realms cover-card picker
- prose-only preset (locks the model to fiction)
- /export-story typesets the session into a Markdown novel

Install:
```
dsh plugin --profile web add github:vdnight89/InfiniteDSH
```