### PR TITLE
Add DSHEssentialTools (DET) — permanent DeepSeek Harness plugin

### DIFF
--- a/categories/tools-capabilities.md
+++ b/categories/tools-capabilities.md
@@ -9,6 +9,7 @@
 
 ---
 
+- [LLYlab/DSHEssentialTools](https://github.com/LLYlab/DSHEssentialTools) — 永久 DSH 插件：LVAL 工程运行/代码查看/程序版本快照回退 + VTD 虚拟对话树（编辑/重试/分支、消息小版本）+ 全局插件控制 + DeepSeek 余额/官网单价。A permanent DeepSeek Harness plugin: project run & code viewer, program snapshots, an in-session conversation tree (edit/retry/branches), global plugin control, and DeepSeek balance/price.
 - [anywhere-labs/deepseek-harness-desktop](https://github.com/anywhere-labs/dsh-desktop) ⭐20961 — 为 DeepSeek Harness (DSH) 插件生态打造的现代化桌面端解决方案。万物皆「插件」，桌面本身也是「插件」。
 - [Devin-AXIS/iPolloWork](https://github.com/Devin-AXIS/iPolloWork) ⭐4944 — Enterprise-grade, local-first Agent Workbench for people and agent teams. A unified multi-engine workspace for Codex Harness, DeepSeek Harness, and OpenCode, with unified plugins and Skills, multi-agent projects and tasks, and editable code, documents, presentations, design, and video.
 - [xiaobright/dsh-anchored-standard](https://github.com/xiaobright/dsh-anchored-standard) ⭐3770 — Two-phase DeepSeek Harness preset: Minimal-aligned bootstrap, then full Standard tools (Project2 98/99)


### PR DESCRIPTION
## What

Add [LLYlab/DSHEssentialTools](https://github.com/LLYlab/DSHEssentialTools) (DSH Essential Tools, “DET”) to **Tools & Capabilities** — a permanent DeepSeek Harness (DSH) plugin.

A permanent plugin with:
- 工程运行/代码查看/程序版本快照回退（LVAL 工程工具）· project run & code viewer · program snapshots/rollback
- VTD 虚拟对话树：会话内编辑/重试/分支、消息小版本 · in-session conversation tree (edit/retry/branches)
- 全局插件控制（五档位：全局启用/AI 可自行决定/需审批/不再会有新启用/全局禁用；跨会话拉取 + 商店下载 + AI 摘要缓存）
- DeepSeek 余额（右下角）/ 官网单价（CNY 计价、峰值/错峰）/ 消耗估算

One line added to `categories/tools-capabilities.md`.

## Why

Fills the “project run + conversation-tree + global plugins + DeepSeek balance” slot for the DSH plugin ecosystem; it is a real, published, code-reviewed DeepSeek Harness plugin.